### PR TITLE
Add -g|--hostGroup flag.

### DIFF
--- a/bin/eshost.js
+++ b/bin/eshost.js
@@ -79,6 +79,11 @@ if (argv.c) {
 }
 
 let hosts = [];
+if (Array.isArray(argv.h)) {
+  hosts = argv.h;
+} else if (typeof argv.h === 'string') {
+  hosts = argv.h.split(',');
+}
 
 let hostGroups;
 if (Array.isArray(argv.g)) {
@@ -91,17 +96,11 @@ if (hostGroups) {
   for (let group of hostGroups) {
     for (let hostName of Object.keys(config.hosts)) {
       let hostType = config.hosts[hostName].type;
-      if (group === hostType) {
+      if (group === hostType && !hosts.includes(hostName)) {
         hosts.push(hostName);
       }
     }
   }
-}
-
-if (Array.isArray(argv.h)) {
-  hosts = hosts.concat(argv.h);
-} else if (typeof argv.h === 'string') {
-  hosts = hosts.concat(argv.h.split(','));
 }
 
 // if hosts is still empty, get all hosts from config

--- a/bin/eshost.js
+++ b/bin/eshost.js
@@ -14,6 +14,7 @@ const TableReporter = require('../lib/reporters/table.js');
 
 const usage = `
 Usage: eshost [options] [input-file]
+       eshost [options] -e "input-script"
        eshost --list
        eshost --add [host name] [host type] <host path> <host arguments>
        eshost --delete [host name]
@@ -26,6 +27,9 @@ const yargv = yargs
   .alias('e', 'eval')
   .describe('h', 'select hosts by name')
   .alias('h', 'host')
+  .describe('g', 'select host groups by host type')
+  .alias('g', 'hostGroup')
+  .nargs('g', 1)
   .describe('c', 'select a config file')
   .alias('c', 'config')
   .describe('table', 'output in a table')
@@ -53,6 +57,9 @@ const yargv = yargs
   .example('eshost test.js')
   .example('eshost -e "1+1"')
   .example('eshost -h d8 -h chakra test.js')
+  .example('eshost -h d8,sm test.js')
+  .example('eshost -g node,ch test.js')
+  .example('eshost -h d8 -g node test.js')
   .fail(function (msg, err) {
     if (err) {
       console.error(err.stack);
@@ -71,12 +78,34 @@ if (argv.c) {
   config = Config.defaultConfig();
 }
 
-let hosts;
+let hosts = [];
+
+let hostGroups;
+if (Array.isArray(argv.g)) {
+  hostGroups = argv.g;
+} else if (typeof argv.g === 'string') {
+  hostGroups = argv.g.split(',');
+}
+
+if (hostGroups) {
+  for (let group of hostGroups) {
+    for (let hostName of Object.keys(config.hosts)) {
+      let hostType = config.hosts[hostName].type;
+      if (group === hostType) {
+        hosts.push(hostName);
+      }
+    }
+  }
+}
+
 if (Array.isArray(argv.h)) {
-  hosts = argv.h;
+  hosts = hosts.concat(argv.h);
 } else if (typeof argv.h === 'string') {
-  hosts = argv.h.split(',');
-} else {
+  hosts = hosts.concat(argv.h.split(','));
+}
+
+// if hosts is still empty, get all hosts from config
+if (hosts.length === 0) {
   hosts = Object.keys(config.hosts);
 }
 


### PR DESCRIPTION
When the `-g` flag is specified, it will select all hosts in the config that match that host type. Combines with `-h`.

Example:

```
$ node eshost.js --coalesce -h d8,sm -g node -e "1+1"
#### d8, sm, node-ch, node
2
```

