### PR TITLE
Fix tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "^3.5.0"
   },
   "scripts": {
-    "test": "mocha test/**/*"
+    "test": "mocha test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/bin/eshost.js
+++ b/test/bin/eshost.js
@@ -39,10 +39,9 @@ function eshost(command = []) {
   }
 
   return new Promise((resolve, reject) => {
-    let cps = cp.spawn('./bin/eshost.js', args);
+    let cps = cp.spawn(process.execPath, ['./bin/eshost.js'].concat(args));
     let stdout = '';
     let stderr = '';
-
     cps.stdout.on('data', buffer => { stdout += buffer; });
     cps.stderr.on('data', buffer => { stderr += buffer; });
     cps.on('close', () => {


### PR DESCRIPTION
On windows, mocha attempts to invoke the directory `test/bin`, and you can't exec a js file even with a shebang. Can someone ensure this works on other platforms as well?