### PR TITLE
Fix unanimous output

### DIFF
--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const chalk = require('chalk');
 
 module.exports = class Reporter {

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Reporter = require('../Reporter.js');
 const chalk = require('chalk');
 
@@ -8,6 +10,7 @@ module.exports = class DefaultReporter extends Reporter {
     this.results = [];
     this.resultsMap = {};
   }
+
   start(source) {
     this.source = source;
 
@@ -15,6 +18,7 @@ module.exports = class DefaultReporter extends Reporter {
       Reporter.printSource(source);
     }
   }
+
   result(host, result) {
     let resultString = result.stdout.trim();
     if (result.error) {
@@ -33,6 +37,7 @@ module.exports = class DefaultReporter extends Reporter {
       printHostResult(host.name, resultString);
     }
   }
+
   end() {
     if (this.options.coalesce) {
       if (this.options.unanimous && this.isUnanimous) {

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -14,7 +14,7 @@ module.exports = class DefaultReporter extends Reporter {
   start(source) {
     this.source = source;
 
-    if (this.options.showSource) {
+    if (this.options.showSource && !this.options.unanimous) {
       Reporter.printSource(source);
     }
   }

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Reporter = require('../Reporter.js');
 const chalk = require('chalk');
 const Table = require('cli-table');
@@ -13,7 +15,7 @@ module.exports = class TableReporter extends Reporter {
   start(source) {
     this.source = source;
 
-    if (this.options.showSource) {
+    if (this.options.showSource && !this.options.unanimous) {
       Reporter.printSource(source);
     }
   }
@@ -36,18 +38,19 @@ module.exports = class TableReporter extends Reporter {
 
   end() {
     if (this.options.unanimous && this.isUnanimous) {
+      // print nothing
       process.exit(0);
-      // don't print anything
-    } else {
-      if (this.options.showSource) {
-        Reporter.printSource(this.source);
-      }
+    }
 
-      console.log(this.results.toString());
+    // was not unanimous
+    if (this.options.unanimous && this.options.showSource) {
+      Reporter.printSource(this.source);
+    }
 
-      if (this.options.unanimous) {
-        process.exit(1);
-      }
+    console.log(this.results.toString());
+
+    if (this.options.unanimous && !this.isUnanimous) {
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
This is something I had on the backburner since --unanimous was added.

--unanimous was printing output when it shouldn't when "show input" was passed and engines were unanimous.

This also fixes some issues with double-printing of input.
