### PR TITLE
Don't clobber config file when running tests

### DIFF
--- a/test/bin/eshost.js
+++ b/test/bin/eshost.js
@@ -8,6 +8,9 @@ const tokenize = require('yargs/lib/tokenize-arg-string');
 
 const Config = require('../../lib/config');
 
+// To avoid messing with a real configuration, use a test-local config
+Config.defaultConfigPath = path.join(__dirname, '../config/.eshost-config.json');
+
 const isWindows = process.platform === 'win32' ||
   process.env.OSTYPE === 'cygwin' ||
   process.env.OSTYPE === 'msys';
@@ -39,7 +42,6 @@ function eshost(command = []) {
 
   let spawnArgs = [
     './bin/eshost.js',
-    // To avoid messing with a real configuration, use a test-local config
     '--config',
     Config.defaultConfigPath,
   ].concat(args);


### PR DESCRIPTION
It looks like #43 was supposed to do this, but got messed up during review or rebasing or something.