### PR TITLE
Only print source once in table mode

### DIFF
--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -39,10 +39,6 @@ module.exports = class TableReporter extends Reporter {
       process.exit(0);
       // don't print anything
     } else {
-      if (this.options.showSource) {
-        Reporter.printSource(this.source);
-      }
-
       console.log(this.results.toString());
 
       if (this.options.unanimous) {


### PR DESCRIPTION
Fixes #45.

When `showSource` is set, the table reporter prints the source twice - once at the [start](https://github.com/bterlson/eshost-cli/blob/3c98071fb72dd3621833ed685fafe64f32b4f472/lib/reporters/table.js#L16), once at the end.

Only do it at the start.