### PR TITLE
Consistent order for host results

### DIFF
--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -3,9 +3,30 @@ const chalk = require('chalk');
 module.exports = class Reporter {
   constructor (options = {}) {
     this.options = options;
+    this.source = undefined;
+    this.results = [];
   }
-  start() {}
-  result(host, result) {}
+
+  start(source) {
+    this.source = source;
+
+    if (this.options.showSource) {
+      Reporter.printSource(source);
+    }
+  }
+
+  result(host, result) {
+    let resultCell = result.stdout.trim();
+    if (result.error) {
+      resultCell += '\n' + chalk.red(`${result.error.name}: ${result.error.message}`);
+    }
+    resultCell = resultCell.replace(/\r/g, '');
+
+    this.results.push([
+      host.name, resultCell
+    ]);
+  }
+
   end() {}
 
   get isUnanimous() {

--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -24,33 +24,15 @@ module.exports = class Reporter {
     return true;
   }
 
-  static coalesceInto(records, host, result, resultsMap /*{result:[...hosts]}*/, sep = "\n") {
-    let found = false;
-
-    for (let record of records) {
-      if (record[1] === result) {
-        let hosts = resultsMap[result];
-        hosts.push(host);
-        hosts.sort((a,b) => a.name.localeCompare(b.name));
-
-        let text = hosts[0].name;
-        hosts.slice(1).forEach((x) => {
-          text += sep + x.name;
-        });
-        text = text.trim();
-        record[0] = text;
-
-        found = true;
-        break;
+  static coalsece(records) {
+    const resultsMap = new Map();
+    for (const [ name, resultString ] of records) {
+      if (!resultsMap.has(resultString)) {
+        resultsMap.set(resultString, []);
       }
+      resultsMap.get(resultString).push(name);
     }
-
-    if (!found) {
-      resultsMap[result] = [host];
-      records.push([
-        host.name, result
-      ]);
-    }
+    return [...resultsMap];
   }
 
   static printSource(source) {

--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -45,7 +45,7 @@ module.exports = class Reporter {
     return true;
   }
 
-  static coalsece(records) {
+  static coalesce(records) {
     const resultsMap = new Map();
     for (const [ name, resultString ] of records) {
       if (!resultsMap.has(resultString)) {

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -9,7 +9,7 @@ module.exports = class DefaultReporter extends Reporter {
     } else {
       this.results.sort((a,b) => a[0].localeCompare(b[0]));
       if (this.options.coalesce) {
-        for (const [ resultString, hosts ] of Reporter.coalsece(this.results)) {
+        for (const [ resultString, hosts ] of Reporter.coalesce(this.results)) {
           const joinedHosts = hosts.join(", ").trim();
           printHostResult(joinedHosts, resultString);
         }

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -21,32 +21,29 @@ module.exports = class DefaultReporter extends Reporter {
       resultString += chalk.red(`${result.error.name}: ${result.error.message}`);
     }
 
-    if (this.options.coalesce) {
-      if (this.options.unanimous) {
-        this.results.push([
-          host.name, resultString
-        ]);
-      } else {
-        Reporter.coalesceInto(this.results, host, resultString, this.resultsMap, ", ");
-      }
-    } else {
-      printHostResult(host.name, resultString);
-    }
+    this.results.push([
+      host.name, resultString
+    ]);
   }
   end() {
-    if (this.options.coalesce) {
-      if (this.options.unanimous && this.isUnanimous) {
-        process.exit(0);
-        // don't print anything
-      } else {
-
-        this.results.forEach(row => {
-          printHostResult(row[0], row[1]);
-        });
+    if (this.options.unanimous && this.isUnanimous) {
+      process.exit(0);
+      // don't print anything
+    } else {
+      this.results.sort((a,b) => a[0].localeCompare(b[0]));
+      if (this.options.coalesce) {
+        for (const [ resultString, hosts ] of Reporter.coalsece(this.results)) {
+          const joinedHosts = hosts.join(", ").trim();
+          printHostResult(joinedHosts, resultString);
+        }
 
         if (this.options.unanimous) {
           process.exit(1);
         }
+      } else {
+        this.results.forEach(row => {
+          printHostResult(row[0], row[1]);
+        });
       }
     }
   }

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -2,29 +2,6 @@ const Reporter = require('../Reporter.js');
 const chalk = require('chalk');
 
 module.exports = class DefaultReporter extends Reporter {
-  constructor(options) {
-    super(options);
-    this.source = undefined;
-    this.results = [];
-    this.resultsMap = {};
-  }
-  start(source) {
-    this.source = source;
-
-    if (this.options.showSource) {
-      Reporter.printSource(source);
-    }
-  }
-  result(host, result) {
-    let resultString = result.stdout.trim();
-    if (result.error) {
-      resultString += chalk.red(`${result.error.name}: ${result.error.message}`);
-    }
-
-    this.results.push([
-      host.name, resultString
-    ]);
-  }
   end() {
     if (this.options.unanimous && this.isUnanimous) {
       process.exit(0);

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -6,7 +6,7 @@ module.exports = class TableReporter extends Reporter {
   constructor(options) {
     super(options);
     this.source = undefined;
-    this.results = new Table();
+    this.results = [];
     this.resultsMap = {};
   }
 
@@ -25,13 +25,9 @@ module.exports = class TableReporter extends Reporter {
     }
     resultCell = resultCell.replace(/\r/g, '');
 
-    if (this.options.coalesce) {
-      Reporter.coalesceInto(this.results, host, resultCell, this.resultsMap);
-    } else {
-      this.results.push([
-        host.name, resultCell
-      ]);
-    }
+    this.results.push([
+      host.name, resultCell
+    ]);
   }
 
   end() {
@@ -39,7 +35,19 @@ module.exports = class TableReporter extends Reporter {
       process.exit(0);
       // don't print anything
     } else {
-      console.log(this.results.toString());
+      this.results.sort((a,b) => a[0].localeCompare(b[0]));
+
+      const table = new Table();
+      if (this.options.coalesce) {
+        for (const [ resultString, hosts ] of Reporter.coalsece(this.results)) {
+          const joinedHosts = hosts.join("\n").trim();
+          table.push([joinedHosts, resultString]);
+        }
+      } else {
+        table.push(...this.results);
+      }
+
+      console.log(table.toString());
 
       if (this.options.unanimous) {
         process.exit(1);

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -12,7 +12,7 @@ module.exports = class TableReporter extends Reporter {
 
       const table = new Table();
       if (this.options.coalesce) {
-        for (const [ resultString, hosts ] of Reporter.coalsece(this.results)) {
+        for (const [ resultString, hosts ] of Reporter.coalesce(this.results)) {
           const joinedHosts = hosts.join("\n").trim();
           table.push([joinedHosts, resultString]);
         }

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -3,33 +3,6 @@ const chalk = require('chalk');
 const Table = require('cli-table');
 
 module.exports = class TableReporter extends Reporter {
-  constructor(options) {
-    super(options);
-    this.source = undefined;
-    this.results = [];
-    this.resultsMap = {};
-  }
-
-  start(source) {
-    this.source = source;
-
-    if (this.options.showSource) {
-      Reporter.printSource(source);
-    }
-  }
-
-  result(host, result) {
-    let resultCell = result.stdout.trim();
-    if (result.error) {
-      resultCell += '\n' + chalk.red(`${result.error.name}: ${result.error.message}`);
-    }
-    resultCell = resultCell.replace(/\r/g, '');
-
-    this.results.push([
-      host.name, resultCell
-    ]);
-  }
-
   end() {
     if (this.options.unanimous && this.isUnanimous) {
       process.exit(0);

--- a/test/bin/eshost.js
+++ b/test/bin/eshost.js
@@ -404,8 +404,7 @@ describe('eshost --unanimous --eval', () => {
       return eshost('--unanimous --eval "typeof gc"').then(result => {
         assert.equal(result.stderr, '');
         assert(/#### js\nfunction/.test(result.stdout));
-        assert(/#### ch\nundefined/.test(result.stdout));
-        assert(/#### node\nundefined/.test(result.stdout));
+        assert(/#### ch, node\nundefined/.test(result.stdout));
       });
     });
   });


### PR DESCRIPTION
Fixes #53.

This also has the effect of making `--unanimous` actually imply `--coalesce`, as it claims to. I can undo that if you like.

It's possible some of the tests should be cleaned up now that they don't have to deal with nondeterminism, but I haven't done that yet.

(Also incidentally fixes #25.)