### PR TITLE
feat: add --markdown formatting

### DIFF
--- a/bin/eshost.js
+++ b/bin/eshost.js
@@ -8,7 +8,6 @@ const readline = require('readline');
 
 const chalk = require('chalk');
 const esh = require('eshost');
-const Table = require('cli-table');
 const uniqueTempDir = require('unique-temp-dir');
 const yargs = require('yargs');
 
@@ -44,6 +43,8 @@ const yargv = yargs
   .describe('table', 'output in a table')
   .boolean('table')
   .alias('table', 't')
+  .describe('markdown', 'output as markdown')
+  .boolean('markdown')
   .describe('coalesce', 'coalesce like output into a single entry')
   .boolean('coalesce')
   .alias('coalesce', 's')
@@ -211,7 +212,8 @@ hosts = [ ... new Set(hosts) ]; // take unique elements
 let reporterOptions = {
   coalesce: argv.coalesce,
   showSource: argv.showSource,
-  unanimous: argv.unanimous
+  unanimous: argv.unanimous,
+  markdown: argv.markdown
 };
 
 let reporter;
@@ -227,7 +229,7 @@ if (argv.list || argv.add || argv.edit || argv.delete ||
 }
 // list available hosts
 if (argv.list) {
-  hostManager.list(config);
+  hostManager.list(config, argv);
   process.exit(0);
 }
 

--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -6,7 +6,7 @@ module.exports = class Reporter {
   constructor(options = {}) {
     this.options = options;
     this.source = undefined;
-    this.results = [];
+    this._results = [];
   }
 
   start(source) {
@@ -24,22 +24,61 @@ module.exports = class Reporter {
     }
     resultCell = resultCell.replace(/\r/g, '');
 
-    this.results.push([
+    this._results.push([
       name, resultCell
     ]);
   }
 
-  end() {}
+  get joinHostDelimiter() { return ''; }
+
+  get results() {
+    this._results.sort((a,b) => a[0].localeCompare(b[0]));
+
+    const results = [];
+    if (this.options.coalesce) {
+      for (const [ resultString, hosts ] of Reporter.coalesce(this._results)) {
+        const joinedHosts = hosts.join(this.joinHostDelimiter).trim();
+        results.push([joinedHosts, resultString]);
+      }
+    } else {
+      results.push(...this._results);
+    }
+
+    return results;
+  }
+
+  printResults(results) { }
+
+  end() {
+    if (this.options.unanimous && this.isUnanimous) {
+      process.exit(0);
+      // don't print anything
+    } else {
+      this.printResults(this.prettyResults(this.results));
+
+      if (this.options.unanimous) {
+        process.exit(1);
+      }
+    }
+  }
+
+  prettyResults(results) {
+    if (this.options.markdown) {
+      return results.map(([host, resultString]) =>
+        [host, `<pre>${resultString}</pre>`.replace(/\n/g, '<br>')]);
+    }
+    return results;
+  }
 
   get isUnanimous() {
-    if (this.results.length === 1) {
+    if (this._results.length === 1) {
       return true;
     }
     // Get the result string of the first result entry
-    let first = this.results[0][1];
+    let first = this._results[0][1];
 
     // Compare the first result string to all result strings
-    for (let [ host, result ] of this.results) {
+    for (let [ host, result ] of this._results) {
       if (result !== first) {
         return false;
       }
@@ -62,4 +101,5 @@ module.exports = class Reporter {
     console.log(chalk.blue('## Source'));
     console.log(`${source}\n`);
   }
+
 }

--- a/lib/host-manager.js
+++ b/lib/host-manager.js
@@ -5,9 +5,9 @@ const os = require('os');
 const path = require('path');
 
 const chalk = require('chalk');
-const Table = require('cli-table')
 
 const Config = require('../lib/config')
+const { buildTable } = require('../lib/table')
 const esh = require('eshost');
 
 const head = [
@@ -18,12 +18,10 @@ const head = [
   'tags',
 ];
 
-const colWidths = head.map(h => h.length + 2);
-
-exports.list = ({configPath, hosts}) => {
-  const table = new Table({
-    colWidths, head
-  });
+exports.list = ({configPath, hosts}, { markdown }) => {
+  const table = [
+    head.map(n => chalk.red(n))
+  ];
 
   const names = Object.keys(hosts);
   let output;
@@ -31,7 +29,7 @@ exports.list = ({configPath, hosts}) => {
   if (!names.length) {
     output = 'No configured hosts';
   } else {
-    output = names.reduce((accum, name) => {
+    output = buildTable(names.sort().reduce((accum, name) => {
       const {
         type,
         path = '',
@@ -40,14 +38,10 @@ exports.list = ({configPath, hosts}) => {
       } = hosts[name];
 
       const row = [ name, type, path, args, tags ];
-      const {colWidths: widths} = accum.options;
-
-      // Update the stored colWidths for each cell, saving the largest/longest
-      accum.options.colWidths = Array.from(widths, (width, index) => Math.max(width, String(row[index]).length + 2));
 
       accum.push(row);
       return accum;
-    }, table).sort().toString();
+    }, table), markdown);
   }
 
   console.log(output);

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -2,31 +2,12 @@ const Reporter = require('../Reporter.js');
 const chalk = require('chalk');
 
 module.exports = class DefaultReporter extends Reporter {
-  end() {
-    if (this.options.unanimous && this.isUnanimous) {
-      process.exit(0);
-      // don't print anything
-    } else {
-      this.results.sort((a,b) => a[0].localeCompare(b[0]));
-      if (this.options.coalesce) {
-        for (const [ resultString, hosts ] of Reporter.coalesce(this.results)) {
-          const joinedHosts = hosts.join(", ").trim();
-          printHostResult(joinedHosts, resultString);
-        }
-
-        if (this.options.unanimous) {
-          process.exit(1);
-        }
-      } else {
-        this.results.forEach(row => {
-          printHostResult(row[0], row[1]);
-        });
-      }
+  printResults(results) {
+    for (const [name, result] of results) {
+      console.log(chalk.blue(`#### ${name}`));
+      if (this.options.markdown)
+        console.log("");
+      console.log(`${result}\n`);
     }
   }
-}
-
-function printHostResult(name, result) {
-  console.log(chalk.blue(`#### ${name}`));
-  console.log(`${result}\n`);
 }

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -1,30 +1,12 @@
 const Reporter = require('../Reporter.js');
 const chalk = require('chalk');
-const Table = require('cli-table');
+
+const { buildTable } = require('../table');
 
 module.exports = class TableReporter extends Reporter {
-  end() {
-    if (this.options.unanimous && this.isUnanimous) {
-      process.exit(0);
-      // don't print anything
-    } else {
-      this.results.sort((a,b) => a[0].localeCompare(b[0]));
+  printResults(results) {
+    let table = [['Engine', 'Results'], ...results];
 
-      const table = new Table();
-      if (this.options.coalesce) {
-        for (const [ resultString, hosts ] of Reporter.coalesce(this.results)) {
-          const joinedHosts = hosts.join("\n").trim();
-          table.push([joinedHosts, resultString]);
-        }
-      } else {
-        table.push(...this.results);
-      }
-
-      console.log(table.toString());
-
-      if (this.options.unanimous) {
-        process.exit(1);
-      }
-    }
+    console.log(buildTable(table, this.options.markdown));
   }
 }

--- a/lib/table.js
+++ b/lib/table.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { table } = require('table')
+const chalk = require('chalk');
+
+function buildTable(content, markdown=false) {
+  if (!markdown) {
+    content[0] = content[0].map((n) => chalk.red(n));
+    return table(content);
+  } else {
+    return table(content, {
+      border: {
+        topBody: '',
+        topJoin: '',
+        topLeft: '',
+        topRight: '',
+        bottomBody: '',
+        bottomJoin: '',
+        bottomLeft: '',
+        bottomRight: '',
+        bodyLeft: '|',
+        bodyRight: '|',
+        bodyJoin: '|',
+        joinBody: '-',
+        joinLeft: '|',
+        joinRight: '|',
+        joinJoin: '|'
+      },
+      drawHorizontalLine: (index) => index === 1
+    });
+  }
+}
+
+module.exports = { buildTable }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,17 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -37,6 +48,11 @@
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
       "integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw=="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
       "version": "1.5.2",
@@ -118,14 +134,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "requires": {
-        "colors": "1.0.3"
-      }
-    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -141,10 +149,18 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
       "version": "2.9.0",
@@ -218,6 +234,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "engine.io": {
       "version": "3.4.0",
@@ -303,6 +324,16 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -430,6 +461,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
@@ -462,6 +498,11 @@
       "requires": {
         "immediate": "~3.0.5"
       }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -731,6 +772,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -793,6 +839,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -928,6 +999,47 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -970,6 +1082,14 @@
         "mkdirp": "^0.5.1",
         "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "cli-table": "^0.3.1",
     "configstore": "^1.4.0",
     "eshost": "^7.3.0",
     "nconf": "^0.8.2",
+    "table": "^5.4.6",
     "temp": "^0.8.3",
     "unique-temp-dir": "^1.0.0",
     "yargs": "^3.31.0"

--- a/test/bin/eshost.js
+++ b/test/bin/eshost.js
@@ -361,32 +361,32 @@ describe('eshost --eval', () => {
     it('evaluates code and displays the result for all hosts', () => {
       return eshost('--table --eval " 1 + 1 "').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+ch.+2.+\│/.test(result.stdout));
-        assert(/\│.+node.+2.+\│/.test(result.stdout));
+        assert(/\║.+ch.+2.+\║/.test(result.stdout));
+        assert(/\║.+node.+2.+\║/.test(result.stdout));
       });
     });
 
     it('evaluates code and displays the result for a specific host', () => {
       return eshost('--table --eval " 1 + 1 " --host ch').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+ch.+2.+\│/.test(result.stdout));
-        assert(!/\│.+node.+2.+\│/.test(result.stdout));
+        assert(/\║.+ch.+2.+\║/.test(result.stdout));
+        assert(!/\║.+node.+2.+\║/.test(result.stdout));
       });
     });
 
     it('evaluates code and displays the result for a specific host group', () => {
       return eshost('--table --eval " 1 + 1 " --hostGroup ch,node').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+ch.+2.+\│/.test(result.stdout));
-        assert(/\│.+node.+2.+\│/.test(result.stdout));
+        assert(/\║.+ch.+2.+\║/.test(result.stdout));
+        assert(/\║.+node.+2.+\║/.test(result.stdout));
       });
     });
 
     it('evaluates code and displays the result for a specific tag', () => {
       return eshost('--table --eval " 1 + 1 " --tags latest').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+ch.+2.+\│/.test(result.stdout));
-        assert(!/\│.+node.+2.+\│/.test(result.stdout));
+        assert(/\║.+ch.+2.+\║/.test(result.stdout));
+        assert(!/\║.+node.+2.+\║/.test(result.stdout));
       });
     });
 
@@ -394,7 +394,7 @@ describe('eshost --eval', () => {
       return eshost('--table --eval " 1 + 1 " --tags latest,greatest').then(result => {
         assert.equal(result.stderr, '');
         assert(/ch/.test(result.stdout));
-        assert(!/\│.+node.+2.+\│/.test(result.stdout));
+        assert(!/\║.+node.+2.+\║/.test(result.stdout));
       });
     });
   });
@@ -448,8 +448,8 @@ describe('eshost --unanimous --eval', () => {
       // and guaranteed to be absent from chakra by default.
       return eshost('--unanimous --table --eval "typeof gc"').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+ch.+undefined.+\│/.test(result.stdout));
-        assert(/\│.+js.+function.+\│/.test(result.stdout));
+        assert(/\║.+ch.+undefined.+\║/.test(result.stdout));
+        assert(/\║.+js.+function.+\║/.test(result.stdout));
       });
     });
   });
@@ -596,24 +596,24 @@ describe('eshost [input-file]', () => {
     it('evaluates code and displays the result for all hosts', () => {
       return eshost('--table test/bin/fixtures/module.mjs').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+engine262.+\│/.test(result.stdout));
-        assert(/\│.+node.+\│/.test(result.stdout));
+        assert(/\║.+engine262.+\║/.test(result.stdout));
+        assert(/\║.+node.+\║/.test(result.stdout));
       });
     });
 
     it('evaluates code and displays the result for a specific host group', () => {
       return eshost('--table test/bin/fixtures/module.mjs --hostGroup engine262,node').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+engine262.+\│/.test(result.stdout));
-        assert(/\│.+node.+\│/.test(result.stdout));
+        assert(/\║.+engine262.+\║/.test(result.stdout));
+        assert(/\║.+node.+\║/.test(result.stdout));
       });
     });
 
     it('evaluates code and displays the result for a specific tag', () => {
       return eshost('--table test/bin/fixtures/module.mjs --tags latest').then(result => {
         assert.equal(result.stderr, '');
-        assert(/\│.+engine262.+\│/.test(result.stdout));
-        assert(!/\│.+node.+\│/.test(result.stdout));
+        assert(/\║.+engine262.+\║/.test(result.stdout));
+        assert(!/\║.+node.+\║/.test(result.stdout));
       });
     });
 
@@ -621,7 +621,7 @@ describe('eshost [input-file]', () => {
       return eshost('--table test/bin/fixtures/module.mjs --tags latest,greatest').then(result => {
         assert.equal(result.stderr, '');
         assert(/engine262/.test(result.stdout));
-        assert(!/\│.+node.+\│/.test(result.stdout));
+        assert(!/\║.+node.+\║/.test(result.stdout));
       });
     });
   });


### PR DESCRIPTION
Markdown formatting can help users share the results on platforms like
GitHub.

Here's an example of a readme generated using `eshost -t --markdown ...`: https://github.com/mmarchini/proposal-error-stacks/tree/engines-comparison/testcases