### PR TITLE
Support tilde expansion and relative host-paths

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -30,6 +30,26 @@ class Config {
     Object.keys(config).forEach(k => this[k] = config[k]);
 
     this.hosts = this.hosts || {};
+
+    for (const hostName in this.hosts) {
+      const host = this.hosts[hostName];
+
+      if (typeof host !== 'object' || host === null) {
+        continue;
+      }
+
+      host.path = this.resolvePath(host.path);
+    }
+  }
+
+  resolvePath(input) {
+    if (input.startsWith('~/')) {
+      return path.join(os.homedir(), input.slice(2));
+    } else if (input === '~') {
+      return os.homedir();
+    } else {
+      return input;
+    }
   }
 
   save() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,8 @@ class Config {
       return path.join(os.homedir(), input.slice(2));
     } else if (input === '~') {
       return os.homedir();
+    } else if (!path.isAbsolute(input)) {
+      return path.join(path.dirname(this.configPath), input);
     } else {
       return input;
     }


### PR DESCRIPTION
This commit introduces two enhancements to the way host-paths are resolved:

*	Tilde expansion is supported so `~/.jsvu/v8` resolves with `/Users/${USER}/.jsvu/v8`. This is for the benefit of users who keep their `.eshost-config.json` files tracked in a dotfile repository.

*	Relative paths are supported so that `./file/foo` is resolved relative to the containing config file. This may be useful when specifying a manual config paths (i.e., those not situated in `$HOME`).

	For example, if `/tmp/.eshosts.json` contains…
	~~~json
	{
		"hosts": {
			"v8": {
				"type": "d8",
				"path": "./dir/v8"
			}
		}
	}
	~~~
	…then V8's path will resolve to `/tmp/dir/v8`.