### PR TITLE
Fix `eshost -e '0'`

### DIFF
--- a/bin/eshost.js
+++ b/bin/eshost.js
@@ -336,7 +336,7 @@ if (fileArg) {
     }
   }
 
-  if (argv.e) {
+  if (argv.e != null) {
     let contents = `print(${argv.e})`;
     fs.writeFileSync(file, contents);
     runInEachHost({file, contents, attrs}, hosts);


### PR DESCRIPTION
`yargs` interprets `-e '0'` as setting `argv.e` to the Number value `0`, and `0` is falsy.