### PR TITLE
jsvu now uses a bin directory as well

### DIFF
--- a/lib/host-manager.js
+++ b/lib/host-manager.js
@@ -115,7 +115,7 @@ exports.delete = (config, hostName) => {
 
 const VU_BIN_PATH = {
   esvu: 'bin',
-  jsvu: '',
+  jsvu: 'bin',
 };
 
 const VU_HOST_DETAILS = {


### PR DESCRIPTION
This fixes the `--configure-jsvu` feature to account for the binaries being moved to `~/.jsvu/bin` in https://github.com/GoogleChromeLabs/jsvu/pull/123.

My work-around for now was running `for f in $(ls bin/); do ln -s bin/"$f" "$f"; done` in `~/.jsvu`.